### PR TITLE
[BB-7244] Backport fix for missing association of ContentMetadata and CatalogQuery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bash -c 'while true; do cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG; sleep 2; done'
+    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -l DEBUG'
     container_name: enterprise.catalog.worker
     depends_on:
       - mysql

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -705,54 +705,6 @@ def _create_new_content_metadata(nonexisting_metadata_defaults):
     return metadata_list
 
 
-def generate_content_metadata_diff(metadata):
-    """
-    Creates, updates and differentiates content metadata objects.
-
-    Generates two lists of content metadata items, items to delete and items to create, based on a provided list of
-    metadata by comparing provided records with existing ones.
-
-    Arguments:
-        metadata (list): List of content metadata dictionaries.
-
-    Returns:
-        metadata_to_create_list: The list of ContentMetaData that have been created
-        metadata_to_delete_list: The list of ContentMetaData that need to be deleted
-        associated_metadata: Subset list of all existing records out of the metadata items provided
-    """
-    metadata_to_create_list = []
-    associated_metadata = []
-    potential_items_to_delete = {item.content_key: item for item in ContentMetadata.objects.all()}
-    for batched_metadata in batch(metadata, batch_size=100):
-        content_keys = [get_content_key(entry) for entry in batched_metadata]
-        existing_metadata = ContentMetadata.objects.filter(content_key__in=content_keys)
-        existing_metadata_by_key = {metadata.content_key: metadata for metadata in existing_metadata}
-
-        for key in existing_metadata_by_key.keys():
-            try:
-                del potential_items_to_delete[key]
-            except KeyError as e:
-                LOGGER.warning(
-                    f'Found existing piece of content: {e} that was not contained by the list of items to delete'
-                )
-
-        existing_metadata_defaults, nonexisting_metadata_defaults = _partition_content_metadata_defaults(
-            batched_metadata, existing_metadata_by_key
-        )
-
-        # Update existing ContentMetadata records
-        updated_metadata = _update_existing_content_metadata(existing_metadata_defaults, existing_metadata_by_key)
-        associated_metadata.extend(updated_metadata)
-
-        # Create new ContentMetadata records
-        created_metadata = _create_new_content_metadata(nonexisting_metadata_defaults)
-        metadata_to_create_list.extend(created_metadata)
-        associated_metadata.extend(created_metadata)
-
-    metadata_to_delete_list = list(potential_items_to_delete.values())
-    return metadata_to_create_list, metadata_to_delete_list, associated_metadata
-
-
 def create_content_metadata(metadata):
     """
     Creates or updates a ContentMetadata object.
@@ -795,13 +747,14 @@ def associate_content_metadata_with_query(metadata, catalog_query):
     Returns:
         list: The list of content_keys for the metadata associated with the query.
     """
-    metadata_to_create_list, metadata_to_delete_list, associated_metadata = generate_content_metadata_diff(metadata)
+    metadata_list = create_content_metadata(metadata)
 
-    for item in metadata_to_delete_list:
-        catalog_query.contentmetadata_set.remove(item)
-    for item in metadata_to_create_list:
-        catalog_query.contentmetadata_set.add(item)
-    associated_content_keys = [metadata.content_key for metadata in associated_metadata]
+    # Setting `clear=True` will remove all prior relationships between
+    # the CatalogQuery's associated ContentMetadata objects
+    # before setting all new relationships from `metadata_list`.
+    # https://docs.djangoproject.com/en/2.2/ref/models/relations/#django.db.models.fields.related.RelatedManager.set
+    catalog_query.contentmetadata_set.set(metadata_list, clear=True)
+    associated_content_keys = [metadata.content_key for metadata in metadata_list]
     return associated_content_keys
 
 

--- a/enterprise_catalog/apps/catalog/tests/factories.py
+++ b/enterprise_catalog/apps/catalog/tests/factories.py
@@ -12,7 +12,6 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     CatalogQuery,
     ContentMetadata,
-    ContentMetadataToQueries,
     EnterpriseCatalog,
     EnterpriseCatalogFeatureRole,
     EnterpriseCatalogRoleAssignment,
@@ -117,17 +116,6 @@ class ContentMetadataFactory(factory.django.DjangoModelFactory):
                 'visible_via_association': True,
             })
         return json_metadata
-
-
-class ContentMetadataToQueriesFactory(factory.django.DjangoModelFactory):
-    """
-    Test factory for the `ContentMetadata` model
-    """
-    catalog_query = factory.SubFactory(CatalogQueryFactory)
-    content_metadata = factory.SubFactory(ContentMetadataFactory)
-
-    class Meta:
-        model = ContentMetadataToQueries
 
 
 class UserFactory(factory.django.DjangoModelFactory):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -403,7 +403,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
 platformdirs==2.4.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
## Description

1. This backports the [commit](https://github.com/openedx/enterprise-catalog/commit/19f73426b076e63af315c8229b772f887584c810) from the `olive` to the `nutmeg` release. A bug was introduced by the [`generate_metadata_content_diff`](https://github.com/openedx/enterprise-catalog/commit/19f73426b076e63af315c8229b772f887584c810#diff-07aa6c84a624074dd574eb2ee64fff1041f84e7e60ed44c1f661903b944b17edL708) function which prevents the associations between the ContentMetadata and the CatalogQuery to be created, if the ContentMetadata object already exists for the course or a course run. This causes the [contains_content_items](https://github.com/open-craft/enterprise-catalog/blob/d96f4ad5f00d03da195f83f04de7953b19fcd1b8/enterprise_catalog/apps/api/v1/views/enterprise_catalog_contains_content_items.py#L42-L43) API to return `false` for courses in a catalog leading to failures in the Get Course API requests, and enrollment.
2. This also includes the commit to upgrade pip-tools version to 6.6.2 as the older version causes deployments to fail. More details in this [upstream PR](https://github.com/openedx/enterprise-catalog/pull/561)



